### PR TITLE
Adds support for rasters in excess of 4 GB.

### DIFF
--- a/arr.cpp
+++ b/arr.cpp
@@ -67,6 +67,17 @@ int32_t ReadInt32(std::ifstream &fin){
   #endif
 }
 
+uint64_t ReadIndex40(std::ifstream& fin){
+  #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint64_t value = ReadThing<uint32_t>(fin);
+  uint64_t byte5 = ReadThing<uint8_t>(fin);
+  value |= (byte5 << 32);
+  return value;
+  #else
+  #pragma message "Big-endian unimplemented"
+  #endif
+}
+
 float ReadFloat32(std::ifstream &fin){
   #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     return ReadThing<float>(fin);
@@ -523,7 +534,7 @@ MasterTable::MasterTable(std::string filename) : BaseTable(filename) {
   #endif
   for(int f=0;f<nfeaturesx;f++){
     GotoPosition(gdbtablx, 16 + f * size_tablx_offsets);
-    const auto feature_offset = ReadInt32(gdbtablx);
+    const auto feature_offset = ReadIndex40(gdbtablx);
 
     if(feature_offset==0)
       continue;
@@ -611,7 +622,7 @@ RasterBase::RasterBase(std::string filename) : BaseTable(filename) {
 
   for(int f=0;f<nfeaturesx;f++){
     GotoPosition(gdbtablx, 16 + f * size_tablx_offsets);
-    const auto feature_offset = ReadInt32(gdbtablx);
+    const auto feature_offset = ReadIndex40(gdbtablx);
 
     if(feature_offset==0)
       continue;
@@ -927,7 +938,7 @@ RasterData<T>::RasterData(std::string filename, const RasterBase &rb) : BaseTabl
 
   for(int f=0;f<nfeaturesx;f++){
     GotoPosition(gdbtablx, 16 + f * size_tablx_offsets);
-    auto feature_offset = ReadInt32(gdbtablx);
+    auto feature_offset = ReadIndex40(gdbtablx);
 
     if(feature_offset==0)
       continue;
@@ -1093,7 +1104,7 @@ void RasterData<T>::getDimensionsFromData(std::string filename, const RasterBase
 
   for(int f=0;f<nfeaturesx;f++){
     GotoPosition(gdbtablx, 16 + f * size_tablx_offsets);
-    auto feature_offset = ReadInt32(gdbtablx);
+    auto feature_offset = ReadIndex40(gdbtablx);
 
     if(feature_offset==0)
       continue;


### PR DESCRIPTION
This fixes the problem I mentioned in issue #3.

Changing from signed to unsigned 32 bit as suggested allowed rasters up to 4GB to be read, but did not fix the >4GB files. However, I inspected our 4GB files and found that the 5th byte of the feature offset block - which appeared to be assumed to be padding - was actually a 5th byte to a 40 bit integer. After 4 GB worth of data, the byte pattern went from xx xx xx xx 00 to xx xx xx xx 01. Combining this additional byte into the unsigned 32 bit integer allowed us to read our >4GB rasters successfully.

You may want to test this to ensure it indeed holds in all cases. I don't have any >8GB files to test with and a limited number of geodatabases in general. However, it seems to work in every case we have, including a few test cases we made.