### PR TITLE
Add docker contained version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:18.04
+
+LABEL author="Austin Raney"
+LABEL author-email="aaraney@crimson.ua.edu"
+
+ARG URL="https://api.github.com/repos/r-barnes/ArcRasterRescue/releases/latest"
+ARG FILENAME="ArcRasterRescue.tar.gz"
+
+RUN apt-get update && \
+    apt-get install -y\
+    cmake libgdal-dev \
+    zlib1g-dev g++ \
+    wget && \
+    mkdir build && \
+    # Get url of latest release
+    wget -O "${FILENAME}" \
+    `wget -qO- "${URL}" | grep -o "https://api.github.com/repos/r-barnes/ArcRasterRescue/tarball/[^\"]*"` && \
+    # Extract and build
+    tar xf "${FILENAME}" -C build/ --strip-components=1 && \
+    cd build && \
+    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo . &&\
+    make && \
+    # Soft link to /bin
+    ln -s `realpath arc_raster_rescue.exe` /bin/arc_raster_rescue.exe && \
+    # Clean up: remove unneeded packages and clear cache
+    apt-get remove -y \
+    cmake g++ \
+    wget &&\
+    apt-get clean
+
+WORKDIR /home

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,65 @@
+# Usage
+
+Docker must be installed. Its recommended that `docker-compose` is also installed for
+ease of use. The built container is ~800 mb in size.
+
+1. Create a clone of the repository. Then, change to the directory named `docker/`.
+
+```shell
+git clone https://github.com/r-barnes/ArcRasterRescue.git
+cd ArcRasterRescue/docker
+```
+
+2. Build the docker image. This will download and build the latest release
+version of ArcRasterRescue. The image is built using an Ubuntu 18.04 bionic base.
+
+```shell
+docker-compose build
+```
+
+You can verify that the build was successful using `docker images`. Look for an image
+named `arc_raster_rescue`.
+
+3. Once the image is built it's ready to use. Before you use it, its important to
+note that the docker container that is spun up from docker image created in the last
+step will be mounted locally to the `./docker/` directory. This means the geodatabase
+for which you are extracting rasters from must be in the `./docker/` directory. If
+you would like to change this skip down to the second example below.
+
+```shell
+docker-compose run --rm arc_raster_rescue
+root@:/home# arc_raster_rescue.exe <path/to/geodatabase.gdb/> <RASTER NUM> <OUTPUT FILE>
+```
+
+If you would like to change the directory that the container is mounted to, you will
+need to make a tiny modification to the `docker-compose.yaml` file. The first code
+snippet shows the original docker-compose yaml. In this let's say instead the
+geodatabase of interest was in the `~/Documents` directory or somewhere beneath it's
+hierarchy.
+
+```yaml
+# Original docker-compose.yaml
+version: "3.8"
+services:
+  arc_raster_rescue:
+    build: .
+    image: arc_raster_rescue
+    volumes:
+      - .:/home/
+    entrypoint: "/bin/bash"
+```
+Notice the small modification to the line after `volumes`. Once this small change has
+been made, you can re-compose the container using `docker-compose run --rm
+arc_raster_rescue` as shown prior.
+
+```yaml
+# Modified docker-compose.yaml
+version: "3.8"
+services:
+  arc_raster_rescue:
+    build: .
+    image: arc_raster_rescue
+    volumes:
+      - ~/Downloads:/home/
+    entrypoint: "/bin/bash"
+```

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: "3.8"
+services:
+  arc_raster_rescue:
+    build: .
+    image: arc_raster_rescue
+    volumes:
+      - .:/home/
+    entrypoint: "/bin/bash"


### PR DESCRIPTION
Hey @r-barnes!

First off, fantastic project that you all have going here. This work is something that i've wanted for a very long time. As an advocate of QGIS, this work addresses a problem I face frequently. The name of the project sums up my feelings for the most part, maybe `ArcRasterSanityRescuer` captures all of my feelings haha. 

I decided to throw your work into Dockerfile to simply things and potentially help with releases/testing in the future. As it sits now, the latest release of ArcRasterRescue is pulled from github, built, and the executable is linked to `/bin/` for easy access. I used ubuntu 18.04 bionic for simplicity, but admittedly the container size could be brought down using alpine -- however, given the size of `libgdal` I don't think it would cut down on the size substantially ~50 MB. In the future I think it would be useful to determine the pieces of libgdal necessary and create a mini version of this. It would be fairly straightforward to wrap this in some R and python bindings, but based off of the **turn this into a GDAL driver** that might get implicitly taken care. 

Anyways, great work here! Excited to see more and hope to contribute more in the future!