### PR TITLE
Reduce cmake dependency to minimum 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.5)
 
 project(arc_raster_rescue LANGUAGES CXX)
 
@@ -21,7 +21,7 @@ target_link_libraries(arc_raster_rescue PRIVATE ZLIB::ZLIB ${GDAL_LIBRARY})
 target_compile_options(arc_raster_rescue PRIVATE
   -Wall -pedantic -Wno-unused-variable
 )
-target_compile_features(arc_raster_rescue PRIVATE cxx_std_11)
+target_compile_features(arc_raster_rescue PRIVATE cxx_constexpr)
 target_compile_definitions(arc_raster_rescue PUBLIC
   GIT_HASH=\"${GIT_HASH}\"
   COMPILE_TIME=\"${MY_TIMESTAMP}\"
@@ -39,4 +39,4 @@ target_link_libraries(arc_raster_rescue.exe PRIVATE arc_raster_rescue)
 target_compile_options(arc_raster_rescue.exe PRIVATE
   -Wall -pedantic -Wno-unused-variable
 )
-target_compile_features(arc_raster_rescue.exe PRIVATE cxx_std_11)
+target_compile_features(arc_raster_rescue.exe PRIVATE cxx_constexpr)


### PR DESCRIPTION
Following @r-barnes comment in #14, this PR would drop the cmake minimum requirement. The change means that `target_compile_features` cannot refer to `cxx_std_11` and so replaces that requirement with `cxx_constexpr`.

<details><summary>Example build output</summary>

```
$ cmake ..
-- The CXX compiler identification is GNU 5.4.0
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found GDAL: /usr/lib/libgdal.so  
-- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.2.8") 
-- Configuring done
-- Generating done
-- Build files have been written to: .../ArcRasterRescue/build

$ make
Scanning dependencies of target arc_raster_rescue
[ 25%] Building CXX object CMakeFiles/arc_raster_rescue.dir/src/arr.cpp.o
.../ArcRasterRescue/src/arr.cpp: In instantiation of ‘RasterData<T>::RasterData(std::__cxx11::string, const RasterBase&) [with T = unsigned char; std::__cxx11::string = std::__cxx11::basic_string<char>]’:
.../ArcRasterRescue/src/arr.cpp:1246:56:   required from ‘void ExportTypedRasterToGeoTIFF(std::__cxx11::string, std::__cxx11::string, int, std::__cxx11::string) [with T = unsigned char; std::__cxx11::string = std::__cxx11::basic_string<char>]’
.../ArcRasterRescue/src/arr.cpp:1278:84:   required from here
.../ArcRasterRescue/src/arr.cpp:958:9: warning: large integer implicitly truncated to unsigned type [-Woverflow]
   resize(maxpx-minpx, maxpy-minpy, -9999);
         ^
.../ArcRasterRescue/src/arr.cpp:1132:11: warning: large integer implicitly truncated to unsigned type [-Woverflow]
   no_data = -9999; //TODO: This cannot always be NoData.
           ^
.../ArcRasterRescue/src/arr.cpp: In instantiation of ‘RasterData<T>::RasterData(std::__cxx11::string, const RasterBase&) [with T = signed char; std::__cxx11::string = std::__cxx11::basic_string<char>]’:
.../ArcRasterRescue/src/arr.cpp:1246:56:   required from ‘void ExportTypedRasterToGeoTIFF(std::__cxx11::string, std::__cxx11::string, int, std::__cxx11::string) [with T = signed char; std::__cxx11::string = std::__cxx11::basic_string<char>]’
.../ArcRasterRescue/src/arr.cpp:1284:83:   required from here
.../ArcRasterRescue/src/arr.cpp:958:9: warning: overflow in implicit constant conversion [-Woverflow]
   resize(maxpx-minpx, maxpy-minpy, -9999);
         ^
.../ArcRasterRescue/src/arr.cpp:1132:11: warning: overflow in implicit constant conversion [-Woverflow]
   no_data = -9999; //TODO: This cannot always be NoData.
           ^
[ 50%] Linking CXX static library libarc_raster_rescue.a
[ 50%] Built target arc_raster_rescue
Scanning dependencies of target arc_raster_rescue.exe
[ 75%] Building CXX object CMakeFiles/arc_raster_rescue.exe.dir/evaluation/main.cpp.o
[100%] Linking CXX executable arc_raster_rescue.exe
[100%] Built target arc_raster_rescue.exe
```

</details>