### PR TITLE
fix minor typo in main.cpp

### DIFF
--- a/evaluation/main.cpp
+++ b/evaluation/main.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv){
     std::cerr<<"Syntax B, given an FGDB and raster selection number, will output the raster to the indicated output file.\n";
     std::cerr<<"Syntax B also accepts raster names, as listed by Syntax A, as inputs for <Raster>\n";
     std::cerr<<"\nNOTE: The geodatabase path must end with a slash!\n";
-    std::cerr<<"EXAMPLE: ./arc_raster.exe path/to/geodatabase.gdb/ dem03 /z/out.tif\n";
+    std::cerr<<"EXAMPLE: ./arc_raster_rescue.exe path/to/geodatabase.gdb/ dem03 /z/out.tif\n";
     return -1;
   }
 


### PR DESCRIPTION
line 22 was changed: "arc_raster.exe" -> "arc_raster_rescue.exe" to match the name of executable actually created