### PR TITLE
Added #include <array>

### DIFF
--- a/include/arc_raster_rescue/arc_raster_rescue.hpp
+++ b/include/arc_raster_rescue/arc_raster_rescue.hpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <typeinfo>
 #include <vector>
+#include <array>
 
 #ifndef GIT_HASH
   #pragma message "Compiling without a git hash!"


### PR DESCRIPTION
Compile failed because arc_raster_rescue.hpp:134 references template array which was not defined.  [CPPreference std:array](https://en.cppreference.com/w/cpp/container/array) says this is defined in header array.  Adding that header allowed me to successfully compile.  I am assuming other compilers might include this header automatically?

My system: macOS 12.6.3 ARM64
My c++: Apple clang version 14.0.0 (clang-1400.0.29.202)

Reference.  I only have one GDB now that I was interested in extracting the raster.  While the program ran and produced a GeoTIFF with the expected CRS all data values were NODATA.  The raster image size was huge (48GB) which is probably valid for the data but extremely difficult to troubleshoot.  Until I run across a better test case I am not going to try debug further.



